### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Miele-MQTT
 A very simple script to read data and issue commands via Miele@home cloud services, using Mosquitto MQTT
 
+<b>Upgrading from a pre-3.x version</b>
+If you have run the script previously, and just updated to the new version, you need to create a new config file. In order to do that, run the script with the parameter "-c" once. It is not necessary to rename/delete the old config file, as the old file, if it exists, will be used to read out default values.
+
 <b>Before first time use</b>
 The first time you run it, you will be asked for Client ID and Client Key. These keys are managed by Miele developers, so you need to send an email to developer@miele.com to retrieve these. According to the license agreement with Miele, these should not be distributed.
 

--- a/miele-MQTT.php
+++ b/miele-MQTT.php
@@ -3,7 +3,7 @@
 ######
 ######		Miele-MQTT.php
 ######		Script by Ole Kristian Lona, to read data from Miele@home, and transfer through MQTT.
-######		Version 3.1a01
+######		Version 3.1a02
 ######
 ################################################################################################################################################
 
@@ -59,8 +59,8 @@ function getRESTData($url,$postdata,$method,$content,$authorization='')
 	}
 	$result = curl_exec($ch);
 
-	$tmpfname = tempnam($folder,"PHP");
-	file_put_contents($tmpfname, $result);
+	#$tmpfname = tempnam($folder,"PHP");  ####  Used for debugging REST communications
+	#file_put_contents($tmpfname, $result);  ####  Used for debugging REST communications
 
 	if (curl_getinfo($ch,CURLINFO_RESPONSE_CODE) == 302 ) {
 		$returndata=curl_getinfo($ch,CURLINFO_REDIRECT_URL);

--- a/miele-MQTT.php
+++ b/miele-MQTT.php
@@ -3,7 +3,7 @@
 ######
 ######		Miele-MQTT.php
 ######		Script by Ole Kristian Lona, to read data from Miele@home, and transfer through MQTT.
-######		Version 3.1a02
+######		Version 3.1a03
 ######
 ################################################################################################################################################
 
@@ -153,6 +153,7 @@ function createconfig($refresh=false) {
 		if($userid == "") {$userid=$config["email"];}
 		$password=prompt_silent("Please type your password: ");
 		$timetorefresh=readline("How many days before epiry to refresh token? [" . $config['timetorefresh'] . "]: ");
+		if($timetorefresh == "") {$timetorefresh=$config["timetorefresh"];}
 		$country=readline('Please state country in the form of "no-NO, en-EN, etc."[' . $config["country"] . ']: ');
 		if($country == "") {$country=$config["country"];}
 
@@ -258,7 +259,9 @@ function createconfig($refresh=false) {
 		$config = $config . "	'topicbase'=> '" . $topicbase . "'" . PHP_EOL;
 		$config = $config . ");" . PHP_EOL . "?>" . PHP_EOL . PHP_EOL;
 
-		rename($folder . '/miele-config2.php',$folder . '/miele-config2.php.org');
+		if (file_exists($folder . '/miele-config2.php') == true ) {
+			rename($folder . '/miele-config2.php',$folder . '/miele-config2.php.org');
+		}
 		if (file_put_contents($folder . "/miele-config2.php", $config) <> false ) {
 			if($debug){print "Configuration file created!" . PHP_EOL;}
 			$configcreated=true;


### PR DESCRIPTION
Fixed three issues:
- PHP temporary files were left with debug information for HTTP flow
- Timetorefresh parameter was not set if you chose to accept the default value.
- Creating config file if one didn't already exist yielded an error message, due to trying to rename the non-existing file.